### PR TITLE
fix: probe port and path

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -38,12 +38,12 @@ spec:
             - --enable-leader-election
           livenessProbe:
             httpGet:
-              port: http
-              path: /
+              port: http-prom
+              path: /metrics
           readinessProbe:
             httpGet:
-              port: http
-              path: /
+              port: http-prom
+              path: /metrics
           resources:
             limits:
               cpu: 1000m


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

The livenessProbe and readinessProbe failed due to the incorrect HTTP port and path.
```
kubectl describe pod -n source-system kcl-controller-65655b4f4f-7fkdj


Name:             kcl-controller-65655b4f4f-7fkdj
Namespace:        source-system
Priority:         0
Service Account:  default
Node:             ip-10-250-0-117.ec2.internal/10.250.0.117
Start Time:       Tue, 05 Mar 2024 10:22:58 +0800
Labels:           app=kcl-controller
                  pod-template-hash=65655b4f4f
Annotations:      cni.projectcalico.org/containerID: 3dfd59cb77e1a307cbfa71a311cd60f03da3f923621e375531a904125e3c8a25
                  cni.projectcalico.org/podIP: 100.96.3.89/32
                  cni.projectcalico.org/podIPs: 100.96.3.89/32
                  prometheus.io/port: 8083
                  prometheus.io/scrape: true
Status:           Running
IP:               100.96.3.89
IPs:
  IP:           100.96.3.89
Controlled By:  ReplicaSet/kcl-controller-65655b4f4f
Containers:
  manager:
    Container ID:  containerd://38886d3a0e7e893d7a30995862bf2711c3f042d8957074fdf8e50e352b44a920
    Image:         ghcr.io/kcl-lang/flux-kcl-controller:v0.1.0
    Image ID:      ghcr.io/kcl-lang/flux-kcl-controller@sha256:0271d188a60d5ffe23b82edc6e0e01e1cf4c7423448fefb841f1551207be9be7
    Port:          8083/TCP
    Host Port:     0/TCP
    Args:
      --log-level=info
      --enable-leader-election
    State:          Running
      Started:      Tue, 05 Mar 2024 10:23:06 +0800
    Ready:          False
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  1Gi
    Requests:
      cpu:      50m
      memory:   64Mi
    Liveness:   http-get http://:http/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:http/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      RUNTIME_NAMESPACE:        source-system (v1:metadata.namespace)
      KUBERNETES_SERVICE_HOST:  api.seven.perfx-k8s.internal.canary.k8s.ondemand.com
    Mounts:
      /tmp from tmp (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-xhwv4 (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  tmp:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  kube-api-access-xhwv4:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  10m                  default-scheduler  Successfully assigned source-system/kcl-controller-65655b4f4f-7fkdj to ip-10-250-0-117.ec2.internal
  Normal   Pulling    10m                  kubelet            Pulling image "ghcr.io/kcl-lang/flux-kcl-controller:v0.1.0"
  Normal   Pulled     10m                  kubelet            Successfully pulled image "ghcr.io/kcl-lang/flux-kcl-controller:v0.1.0" in 6.867844816s (6.867919115s including waiting)
  Normal   Created    10m                  kubelet            Created container manager
  Normal   Started    10m                  kubelet            Started container manager
  Warning  Unhealthy  9m27s (x9 over 10m)  kubelet            Liveness probe errored: strconv.Atoi: parsing "http": invalid syntax
  Warning  Unhealthy  47s (x70 over 10m)   kubelet            Readiness probe errored: strconv.Atoi: parsing "http": invalid syntax
```

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
